### PR TITLE
Enable edge to edge navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId = "app.gomuks.android"
         minSdk = 33
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/java/app/gomuks/android/MainActivity.kt
+++ b/app/src/main/java/app/gomuks/android/MainActivity.kt
@@ -8,6 +8,8 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.Base64
 import android.util.Log
+import android.view.MotionEvent
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
@@ -30,6 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -129,6 +134,7 @@ class MainActivity : ComponentActivity() {
         val runtime = getRuntime(this)
         session.open(runtime)
         view.setSession(session)
+        addSystemInsets()
 
         File(cacheDir, "upload").mkdirs()
 
@@ -242,6 +248,15 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        val windowInsets = ViewCompat.getRootWindowInsets(window.decorView)
+        val statusBarInset = windowInsets?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+        val offsetEvent = MotionEvent.obtain(ev)
+
+        offsetEvent.offsetLocation(0f, -statusBarInset.toFloat())
+        return super.dispatchTouchEvent(offsetEvent)
+    }
+
     fun getServerURL(): String? {
         return sharedPref.getString(getString(R.string.server_url_key), null)
     }
@@ -250,6 +265,22 @@ class MainActivity : ComponentActivity() {
         val (serverURL, username, password) = getCredentials() ?: Triple("", "", "")
         setContent {
             ServerInput(serverURL, username, password, error)
+        }
+    }
+
+    private fun addSystemInsets() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            if (imeInsets.bottom > 0) {
+                v.setPadding(0, systemInsets.top, 0, imeInsets.bottom)
+            } else {
+                v.setPadding(0, systemInsets.top, 0, 0)
+            }
+
+            insets
         }
     }
 


### PR DESCRIPTION
With the help of @ricardo-duarte-av, edge to edge navigation is now enabled. This allows the gesture navigation pill to be an overlay instead of having a reserved space.

This also fixes the touch being offset on GeckoView, and the keyboard not pushing the view up when it's open. 

Previous PR #1 was closed due to rebasing of branches.