### PR TITLE
Make system bars respect light/dark mode

### DIFF
--- a/app/src/main/java/app/gomuks/android/MainActivity.kt
+++ b/app/src/main/java/app/gomuks/android/MainActivity.kt
@@ -355,7 +355,7 @@ class MainActivity : ComponentActivity() {
         val systemBarIconLight = !isNightMode
         val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
 
-        window.decorView.setBackgroundColor(getColor(R.color.header_color))
+        window.decorView.setBackgroundColor(getColor(R.color.systembars_color))
         windowInsetsController.isAppearanceLightStatusBars = systemBarIconLight
         windowInsetsController.isAppearanceLightNavigationBars = systemBarIconLight
     }

--- a/app/src/main/java/app/gomuks/android/MainActivity.kt
+++ b/app/src/main/java/app/gomuks/android/MainActivity.kt
@@ -3,6 +3,7 @@ package app.gomuks.android
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -129,6 +131,7 @@ class MainActivity : ComponentActivity() {
         val runtime = getRuntime(this)
         session.open(runtime)
         view.setSession(session)
+        updateSystemBarsColours(resources.configuration)
 
         File(cacheDir, "upload").mkdirs()
 
@@ -242,6 +245,11 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        updateSystemBarsColours(newConfig)
+    }
+
     fun getServerURL(): String? {
         return sharedPref.getString(getString(R.string.server_url_key), null)
     }
@@ -340,5 +348,15 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    private fun updateSystemBarsColours(configuration: Configuration) {
+        val isNightMode = configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+        val systemBarIconLight = !isNightMode
+        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+
+        window.decorView.setBackgroundColor(getColor(R.color.header_color))
+        windowInsetsController.isAppearanceLightStatusBars = systemBarIconLight
+        windowInsetsController.isAppearanceLightNavigationBars = systemBarIconLight
     }
 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary_color">#00B24A</color>
-    <color name="header_color">#000000</color>
+    <color name="systembars_color">#000000</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="primary_color">#00B24A</color>
+    <color name="header_color">#000000</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary_color">#00C853</color>
-    <color name="header_color">#171717</color>
+    <color name="systembars_color">#171717</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary_color">#00C853</color>
-    <color name="primary_color_dark">#00B24A</color>
+    <color name="header_color">#171717</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="Theme.Gomuks" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:navigationBarColor">@color/primary_color_dark</item>
-        <item name="android:statusBarColor">@color/primary_color_dark</item>
+        <item name="android:navigationBarColor">@color/primary_color</item>
+        <item name="android:statusBarColor">@color/header_color</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Gomuks" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:navigationBarColor">@color/primary_color</item>
-        <item name="android:statusBarColor">@color/header_color</item>
+        <item name="android:navigationBarColor">@color/systembars_color</item>
+        <item name="android:statusBarColor">@color/systembars_color</item>
     </style>
 </resources>


### PR DESCRIPTION
System bars (status bar and navigation/gesture bar) will change their colour depending if the system in on light or dark mode, with the icons colours changing between white and black accordingly. 

I've used a CSS theme as an example, but the colours can be changed accordingly in the code for the moment. Currently it's set to black (dark mode) and grey (light mode), since the default gomuks theme is always dark. In the future, having a way to retrive the header/top bar colour from the webview and using it as the bars background colour would be preferred.
  
![share_4735003911346528517](https://github.com/user-attachments/assets/7651c0ea-7730-4e87-bb7d-299e7e843c91)
![share_6315089677497505089](https://github.com/user-attachments/assets/d6fa4a2c-ae25-4087-9b50-25eed6940682)
